### PR TITLE
Migrate k8s manifests from use the GA Workloads API

### DIFF
--- a/deployment/calico.yaml
+++ b/deployment/calico.yaml
@@ -305,7 +305,7 @@ spec:
 
 # This manifest creates a Deployment of Typha to back the above service.
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: calico-typha
@@ -321,6 +321,9 @@ spec:
   # production, we recommend running at least 3 replicas to reduce the impact of rolling upgrade.
   replicas: 1
   revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      k8s-app: calico-typha
   template:
     metadata:
       labels:
@@ -410,7 +413,7 @@ spec:
 # as the Calico CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: calico-node
   namespace: kube-system

--- a/pwn/100-rot13/oci/deployment/deploy.yaml
+++ b/pwn/100-rot13/oci/deployment/deploy.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pwn100
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: pwn100
   template:
     metadata:
       name: pwn100

--- a/pwn/300-pwnchess/oci/deployment/deploy.yaml
+++ b/pwn/300-pwnchess/oci/deployment/deploy.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pwn300
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: pwn300
   template:
     metadata:
       name: pwn300

--- a/web/100-signedsealed/oci/deployment/deploy_backend.yaml
+++ b/web/100-signedsealed/oci/deployment/deploy_backend.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web100-backend
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: web100-backend
   template:
     metadata:
       name: web100-backend

--- a/web/100-signedsealed/oci/deployment/deploy_frontend.yaml
+++ b/web/100-signedsealed/oci/deployment/deploy_frontend.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web100-frontend
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: web100-frontend
   template:
     metadata:
       name: web100-frontend

--- a/web/200-yourstruly/oci/deployment/deploy_backend.yaml
+++ b/web/200-yourstruly/oci/deployment/deploy_backend.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web200-backend
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: web200-backend
   template:
     metadata:
       name: web200-backend

--- a/web/200-yourstruly/oci/deployment/deploy_minio.yaml
+++ b/web/200-yourstruly/oci/deployment/deploy_minio.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web200-minio
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: web200-minio
   template:
     metadata:
       name: web200-minio

--- a/web/200-yourstruly/oci/deployment/deploy_store.yaml
+++ b/web/200-yourstruly/oci/deployment/deploy_store.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web200-store
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: web200-store
   template:
     metadata:
       name: web200-store

--- a/web/300-helljs/oci/deployment/deploy_frontend.yaml
+++ b/web/300-helljs/oci/deployment/deploy_frontend.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web300-frontend
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: web300-frontend
   template:
     metadata:
       name: web300-frontend

--- a/web/300-helljs/oci/deployment/deploy_secure_backend.yaml
+++ b/web/300-helljs/oci/deployment/deploy_secure_backend.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web300-secure-backend
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: web300-secure-backend
   template:
     metadata:
       name: web300-secure-backend

--- a/web/300-helljs/oci/deployment/deploy_vulnerable_backend.yaml
+++ b/web/300-helljs/oci/deployment/deploy_vulnerable_backend.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web300-vulnerable-backend
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: web300-vulnerable-backend
   template:
     metadata:
       name: web300-vulnerable-backend


### PR DESCRIPTION
Kubernetes 1.9 introduced the `apps/v1` API group[1], marking the GA
release of the `DaemonSet`, `Deployment`, `ReplicaSet` and `StatefulSet`
APIs/objects.

With the 1.9 release, the use of `extensions/v1beta1`, `apps/v1beta1`
and `apps/v1beta2` were deprecated. As of Kubernetes 1.16 these
deprecated API groups are removed[2] resulting in errors when attempting
to deploy workloads defined with old versions of the Workloads API:

```
unable to recognize "calico.yaml": no matches for kind "Deployment" in version "apps/v1beta1"
unable to recognize "calico.yaml": no matches for kind "DaemonSet" in version "extensions/v1beta1"
```

This commit adds a `.spec.selector` section to Deployment objects as
this has been a mandatory field since `apps/v1beta2`

[1] https://kubernetes.io/blog/2017/12/kubernetes-19-workloads-expanded-ecosystem/
[2] https://kubernetes.io/blog/2019/09/18/kubernetes-1-16-release-announcement/